### PR TITLE
manifest.json 'start_url' line modified for Android chrome package

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "WeatherMate App - Real-time Weather Updates",
   "description": "A weather app that displays real-time weather and forecast information for any location.",
   "author": "Son Nguyen",
-  "start_url": "/",
+  "start_url": "https://hoangsonww.github.io/WeatherMate-App/",
   "background_color": "#c9dfff",
   "display": "standalone",
   "scope": "/",


### PR DESCRIPTION
I just changed a bit the manifest.json because I've seen that I wasn't able to download chrome package on Android. I made the same error in my own repos. Actually, I can download it but I'm not opening the right page in the app. With this parameter in 'start_url', it may work better.
